### PR TITLE
[FIX] "No file found" continue and not enter infinite cycle

### DIFF
--- a/no gtk/client.c
+++ b/no gtk/client.c
@@ -124,6 +124,10 @@ int main(int argc, char *argv[])
         unsigned long serverChecksum;
 
         recv(clientSocket, receivedFileName, sizeof(receivedFileName), 0);
+        if (strcmp(receivedFileName, "File not found") == 0) {
+            printf("Server: File '%s' not found.\n", fileName);
+            continue;
+        }
         recv(clientSocket, (char *)&fileSize, sizeof(fileSize), 0);
         recv(clientSocket, (char *)&serverChecksum, sizeof(serverChecksum), 0);
 

--- a/no gtk/server.c
+++ b/no gtk/server.c
@@ -101,7 +101,7 @@ int main() {
             FILE *file = fopen(fileName, "rb");
             if (file == NULL) {
                 printf("Error: File %s not found.\n", fileName);
-                closesocket(clientSocket);
+                send(clientSocket, "File not found", strlen("File not found") + 1, 0);
                 continue;
             }
 


### PR DESCRIPTION
This pull request includes changes to improve error handling when a file is not found on the server. The most important changes include adding a check for the "File not found" message on the client side and modifying the server to send this message when a file is missing.

Error handling improvements:

* [`no gtk/client.c`](diffhunk://#diff-701ab4c4bcd7e7afb3296eabdd7045c1891a8f361e0f886c953d8cf9d08115f5R127-R130): Added a check to handle the "File not found" message from the server and print an appropriate message on the client side.
* [`no gtk/server.c`](diffhunk://#diff-42560f664cb199378d5065efd6f914338611ec0ce2611ff8cd0f7d91e5210f78L104-R104): Modified the server to send a "File not found" message to the client instead of closing the socket when a file is missing.